### PR TITLE
Fix battery index stuff

### DIFF
--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -690,12 +690,13 @@ class E3DC:
             }
         return outObj        
 
-    def get_battery_data(self, keepAlive = False, batIndex = 0):
+    def get_battery_data(self, batIndex = 0, keepAlive = False):
         """Polls the baterry data via rscp protocol locally
         
         Returns:
             Dictionary containing the battery data structured as follows:
                 {
+                    'batIndex': battery index
                     'chargeCycles': charge cycles
                     'current': current
                     'designCapacity': designed capacity
@@ -762,6 +763,7 @@ class E3DC:
         usuableRemainingCapacity = round(rscpFindTag(req, 'BAT_USABLE_REMAINING_CAPACITY')[2],2)
 
         outObj = {
+            'batIndex': batIndex,
             'chargeCycles': chargeCycles,
             'current': current,
             'designCapacity': designCapacity,


### PR DESCRIPTION
Fix battery index stuff. keepAlive should always be on the last position. The battery index should also be returned so the API user knows from which battery they got the data.