### PR TITLE
do not retry on not_available error

### DIFF
--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -12,7 +12,7 @@ import datetime
 import json
 import uuid
 from ._e3dc_rscp_web import E3DC_RSCP_web
-from ._e3dc_rscp_local import E3DC_RSCP_local, RSCPAuthenticationError
+from ._e3dc_rscp_local import E3DC_RSCP_local, RSCPAuthenticationError, RSCPNotAvailableError
 from ._rscpLib import rscpFindTag
 
 REMOTE_ADDRESS='https://s10.e3dc.com/s10/phpcmd/cmd.php'
@@ -20,6 +20,9 @@ REQUEST_INTERVAL_SEC = 10 # minimum interval between requests
 REQUEST_INTERVAL_SEC_LOCAL = 1 # minimum interval between requests
 
 class AuthenticationError(Exception):
+    pass
+
+class NotAvailableError(Exception):
     pass
 
 class PollError(Exception):
@@ -372,6 +375,8 @@ class E3DC:
                 break
             except RSCPAuthenticationError:
                 raise AuthenticationError()
+            except RSCPNotAvailableError:
+                raise NotAvailableError()
             except Exception as err:
                 retry += 1
                 if retry > retries:

--- a/e3dc/_e3dc_rscp_local.py
+++ b/e3dc/_e3dc_rscp_local.py
@@ -16,6 +16,9 @@ BUFFER_SIZE=1024*32
 class RSCPAuthenticationError(Exception):
     pass
 
+class RSCPNotAvailableError(Exception):
+    pass
+
 class CommunicationError(Exception):
     pass
 
@@ -57,6 +60,8 @@ class E3DC_RSCP_local:
             self.disconnect()
             if receive[2] == "RSCP_ERR_ACCESS_DENIED":
                 raise RSCPAuthenticationError
+            elif receive[2] == "RSCP_ERR_NOT_AVAILABLE":
+                raise RSCPNotAvailableError
             else:
                 raise CommunicationError(receive[2])
         return receive

--- a/e3dc/_rscpTags.py
+++ b/e3dc/_rscpTags.py
@@ -1929,7 +1929,8 @@ rscpErrorCodes = {
 	0x05 : "RSCP_ERR_OUT_OF_BOUNDS",
 	0x06 : "RSCP_ERR_NOT_AVAILABLE",
 	0x07 : "RSCP_ERR_UNKNOWN_TAG",
-	0x08 : "RSCP_ERR_ALREADY_IN_USE"
+	0x08 : "RSCP_ERR_ALREADY_IN_USE",
+	0xFFFFFFFF: "UNEXPECTED ERROR"  # happens for example in get_db_data if time and span is invalid (not available)
 }
 
 def getHexDatatype(type_str):


### PR DESCRIPTION
In my case E3DC does not know details about my PV.
It only get's it's information of the production from the DC converters of the PV system.
In consequence the get_pvi_data() throws RSCP_ERR_NOT_AVAILABLE.
This change does just catch and re-raise the specific error and does not retry on it. 