### PR TITLE
Removed fake home power calculation

### DIFF
--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -274,7 +274,7 @@ class E3DC:
         soc = self.sendRequest( ('EMS_REQ_BAT_SOC', 'None', None), keepAlive=True )[2]
         solar = self.sendRequest( ('EMS_REQ_POWER_PV', 'None', None), keepAlive=True )[2]
         bat = self.sendRequest( ('EMS_REQ_POWER_BAT', 'None', None), keepAlive=True )[2]
-        #home = self.sendRequest( ('EMS_REQ_POWER_HOME', 'None', None), keepAlive=True )[2]
+        home = self.sendRequest( ('EMS_REQ_POWER_HOME', 'None', None), keepAlive=True )[2]
         grid = self.sendRequest( ('EMS_REQ_POWER_GRID', 'None', None), keepAlive=True )[2]
         wb = self.sendRequest( ('EMS_REQ_POWER_WB_ALL', 'None', None), keepAlive=True )[2]
 
@@ -283,7 +283,7 @@ class E3DC:
         # last call, use keepAlive value
         autarky = round(self.sendRequest( ('EMS_REQ_AUTARKY', 'None', None), keepAlive=keepAlive )[2],2)
         
-        home = solar + grid - bat - wb # make balance = 0
+        #home = solar + grid - bat - wb # make balance = 0
 
             
         outObj = {


### PR DESCRIPTION
It makes absolute sense, that the sum of powers is not exactly zero, due to conversion losses. These losses are valueable information and should not be discarded by a communication library like this.

If one wants to use "prettified" numbers later on, this calculation should happen outside of the communication library.