### PR TITLE
Fixed pmIndex for S10 Pro

### DIFF
--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -137,7 +137,7 @@ class E3DC:
                 self.serialNumberPrefix = 'Q10-'
         elif self.serialNumber.startswith("7"):
             self.model = "Pro"
-            self.pmIndex = 0
+            self.pmIndex = 6
             self.pmIndexExt = 1
             if not self.serialNumberPrefix:
                 self.serialNumberPrefix = 'P10-'


### PR DESCRIPTION
# Situation
Closes #51, `get_power_data` failed on my S10 Pro system.

# Fix
By trying several different values for `pmIndex` I managed to get power data results when using `pmIndex=6`.