### PR TITLE
Raise AuthenticationError if invalid RSCP key given

### DIFF
--- a/e3dc/__init__.py
+++ b/e3dc/__init__.py
@@ -6,7 +6,7 @@ Licensed under a MIT license. See LICENSE for details.
 """
 
 from ._e3dc import E3DC, AuthenticationError, PollError
-from ._e3dc_rscp_local import CommunicationError, RSCPAuthenticationError
+from ._e3dc_rscp_local import CommunicationError, RSCPAuthenticationError, RSCPKeyError
 from ._e3dc_rscp_web import RequestTimeoutError, SocketNotReady
 from ._rscpLib import FrameError
 
@@ -16,6 +16,7 @@ __all__ = [
     "PollError",
     "CommunicationError",
     "RSCPAuthenticationError",
+    "RSCPKeyError",
     "RequestTimeoutError",
     "SocketNotReady",
     "FrameError",

--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -17,6 +17,7 @@ import requests
 from ._e3dc_rscp_local import (
     E3DC_RSCP_local,
     RSCPAuthenticationError,
+    RSCPKeyError,
     RSCPNotAvailableError,
 )
 from ._e3dc_rscp_web import E3DC_RSCP_web
@@ -505,6 +506,8 @@ class E3DC:
                 raise AuthenticationError()
             except RSCPNotAvailableError:
                 raise NotAvailableError()
+            except RSCPKeyError:
+                raise
             except Exception:
                 retry += 1
                 if retry > retries:

--- a/e3dc/_e3dc_rscp_local.py
+++ b/e3dc/_e3dc_rscp_local.py
@@ -25,6 +25,12 @@ class RSCPNotAvailableError(Exception):
     pass
 
 
+class RSCPKeyError(Exception):
+    """Class for RSCP Encryption Key Error Exception."""
+
+    pass
+
+
 class CommunicationError(Exception):
     """Class for Communication Error Exception."""
 
@@ -88,7 +94,8 @@ class E3DC_RSCP_local:
             raise CommunicationError
 
         if receive is None:
-            raise RSCPAuthenticationError
+            raise RSCPKeyError
+
         if receive[1] == "Error":
             self.disconnect()
             if receive[2] == "RSCP_ERR_ACCESS_DENIED":

--- a/e3dc/_e3dc_rscp_local.py
+++ b/e3dc/_e3dc_rscp_local.py
@@ -58,6 +58,8 @@ class E3DC_RSCP_local:
 
     def _receive(self):
         data = self.socket.recv(BUFFER_SIZE)
+        if len(data) == 0:
+            return None
         decData = rscpDecode(self.encdec.decrypt(data))[0]
         return decData
 
@@ -85,6 +87,8 @@ class E3DC_RSCP_local:
             self.disconnect()
             raise CommunicationError
 
+        if receive is None:
+            raise RSCPAuthenticationError
         if receive[1] == "Error":
             self.disconnect()
             if receive[2] == "RSCP_ERR_ACCESS_DENIED":


### PR DESCRIPTION
Tries to solve issue #17.

Before this PR, when a user passes a wrong RSCP key, an exception is thrown that is hard to understand and does not lead to understanding, that the RSCP key is wrong:
`struct.error: unpack requires a buffer of 2 bytes`
`e3dc._e3dc_rscp_local.CommunicationError`
`e3dc._e3dc.SendError: Max retries reached`

With this PR, you now get a `e3dc._e3dc.AuthenticationError` which at least is a hint, that something with authentication went wrong. 

For discussion: maybe add some exception message hinting to the RSCP key?