### PR TITLE
Added robustness to get_powermeter_data and get_powermeters_data

### DIFF
--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -1807,31 +1807,34 @@ class E3DC:
         )
 
         activePhasesChar = rscpFindTagIndex(res, "PM_ACTIVE_PHASES")
-        activePhases = f"{activePhasesChar:03b}"
+        if activePhasesChar != None:
+            activePhases = f"{activePhasesChar:03b}"
 
-        outObj = {
-            "activePhases": activePhases,
-            "energy": {
-                "L1": rscpFindTagIndex(res, "PM_ENERGY_L1"),
-                "L2": rscpFindTagIndex(res, "PM_ENERGY_L2"),
-                "L3": rscpFindTagIndex(res, "PM_ENERGY_L3"),
-            },
-            "index": pmIndex,
-            "maxPhasePower": rscpFindTagIndex(res, "PM_MAX_PHASE_POWER"),
-            "mode": rscpFindTagIndex(res, "PM_MODE"),
-            "power": {
-                "L1": rscpFindTagIndex(res, "PM_POWER_L1"),
-                "L2": rscpFindTagIndex(res, "PM_POWER_L2"),
-                "L3": rscpFindTagIndex(res, "PM_POWER_L3"),
-            },
-            "type": rscpFindTagIndex(res, "PM_TYPE"),
-            "voltage": {
-                "L1": round(rscpFindTagIndex(res, "PM_VOLTAGE_L1"), 4),
-                "L2": round(rscpFindTagIndex(res, "PM_VOLTAGE_L2"), 4),
-                "L3": round(rscpFindTagIndex(res, "PM_VOLTAGE_L3"), 4),
-            },
-        }
-        return outObj
+            outObj = {
+                "activePhases": activePhases,
+                "energy": {
+                    "L1": rscpFindTagIndex(res, "PM_ENERGY_L1"),
+                    "L2": rscpFindTagIndex(res, "PM_ENERGY_L2"),
+                    "L3": rscpFindTagIndex(res, "PM_ENERGY_L3"),
+                },
+                "index": pmIndex,
+                "maxPhasePower": rscpFindTagIndex(res, "PM_MAX_PHASE_POWER"),
+                "mode": rscpFindTagIndex(res, "PM_MODE"),
+                "power": {
+                    "L1": rscpFindTagIndex(res, "PM_POWER_L1"),
+                    "L2": rscpFindTagIndex(res, "PM_POWER_L2"),
+                    "L3": rscpFindTagIndex(res, "PM_POWER_L3"),
+                },
+                "type": rscpFindTagIndex(res, "PM_TYPE"),
+                "voltage": {
+                    "L1": round(rscpFindTagIndex(res, "PM_VOLTAGE_L1"), 4),
+                    "L2": round(rscpFindTagIndex(res, "PM_VOLTAGE_L2"), 4),
+                    "L3": round(rscpFindTagIndex(res, "PM_VOLTAGE_L3"), 4),
+                },
+            }
+            return outObj
+        else:
+            return None
 
     def get_powermeters_data(self, powermeters=None, keepAlive=False):
         """Polls the powermeters data via rscp protocol locally.
@@ -1849,14 +1852,14 @@ class E3DC:
         outObj = []
 
         for powermeter in powermeters:
-            outObj.append(
-                self.get_powermeter_data(
+            powermeter_data = self.get_powermeter_data(
                     pmIndex=powermeter["index"],
                     keepAlive=True
                     if powermeter["index"] != powermeters[-1]["index"]
                     else keepAlive,  # last request should honor keepAlive
                 )
-            )
+            if powermeter_data != None:
+                outObj.append(powermeter_data)
 
         return outObj
 

--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -1807,34 +1807,34 @@ class E3DC:
         )
 
         activePhasesChar = rscpFindTagIndex(res, "PM_ACTIVE_PHASES")
-        if activePhasesChar != None:
-            activePhases = f"{activePhasesChar:03b}"
-
-            outObj = {
-                "activePhases": activePhases,
-                "energy": {
-                    "L1": rscpFindTagIndex(res, "PM_ENERGY_L1"),
-                    "L2": rscpFindTagIndex(res, "PM_ENERGY_L2"),
-                    "L3": rscpFindTagIndex(res, "PM_ENERGY_L3"),
-                },
-                "index": pmIndex,
-                "maxPhasePower": rscpFindTagIndex(res, "PM_MAX_PHASE_POWER"),
-                "mode": rscpFindTagIndex(res, "PM_MODE"),
-                "power": {
-                    "L1": rscpFindTagIndex(res, "PM_POWER_L1"),
-                    "L2": rscpFindTagIndex(res, "PM_POWER_L2"),
-                    "L3": rscpFindTagIndex(res, "PM_POWER_L3"),
-                },
-                "type": rscpFindTagIndex(res, "PM_TYPE"),
-                "voltage": {
-                    "L1": round(rscpFindTagIndex(res, "PM_VOLTAGE_L1"), 4),
-                    "L2": round(rscpFindTagIndex(res, "PM_VOLTAGE_L2"), 4),
-                    "L3": round(rscpFindTagIndex(res, "PM_VOLTAGE_L3"), 4),
-                },
-            }
-            return outObj
-        else:
+        if activePhasesChar == None:
             return None
+        
+        activePhases = f"{activePhasesChar:03b}"
+
+        outObj = {
+            "activePhases": activePhases,
+            "energy": {
+                "L1": rscpFindTagIndex(res, "PM_ENERGY_L1"),
+                "L2": rscpFindTagIndex(res, "PM_ENERGY_L2"),
+                "L3": rscpFindTagIndex(res, "PM_ENERGY_L3"),
+            },
+            "index": pmIndex,
+            "maxPhasePower": rscpFindTagIndex(res, "PM_MAX_PHASE_POWER"),
+            "mode": rscpFindTagIndex(res, "PM_MODE"),
+            "power": {
+                "L1": rscpFindTagIndex(res, "PM_POWER_L1"),
+                "L2": rscpFindTagIndex(res, "PM_POWER_L2"),
+                "L3": rscpFindTagIndex(res, "PM_POWER_L3"),
+            },
+            "type": rscpFindTagIndex(res, "PM_TYPE"),
+            "voltage": {
+                "L1": round(rscpFindTagIndex(res, "PM_VOLTAGE_L1"), 4),
+                "L2": round(rscpFindTagIndex(res, "PM_VOLTAGE_L2"), 4),
+                "L3": round(rscpFindTagIndex(res, "PM_VOLTAGE_L3"), 4),
+            },
+        }
+        return outObj
 
     def get_powermeters_data(self, powermeters=None, keepAlive=False):
         """Polls the powermeters data via rscp protocol locally.


### PR DESCRIPTION
get_powermeters_data() respective get_powermeter_data() crashes when called with an invalid index of an powermeter.
Without in-depth knowledge of the system, it is hard to know which powermeters with which index are installed.
there is no other function in the library to retrieve the number of installed powermeters.

As a simple mitigation to crashes, i added "None"-Handling to get_powermeter_data() & get_powermeter_data(), so that it simply returns the powermeter data when data is available and omits the other ones if no data is returned.
By that, you can safely call get_powermeters_data() with index 1 ... 4 and see in the results for which ones data is returned.

This function would help greatly, to integrate additional powermeters in this extension https://github.com/torbennehmer/hacs-e3dc by @torbennehmer 