### PR TITLE
Add PM0 & PM1 production to db_day() dict

### DIFF
--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -854,6 +854,8 @@ class E3DC:
                     "startTimestamp": <timestamp from which db data is fetched of>,
                     "stateOfCharge": <battery charge level in %>,
                     "solarProduction": <power production>,
+                    "pm0Production": <power production>,
+                    "pm1Production": <power production>,
                     "timespanSeconds": <timespan in seconds of which db data is collected>
                 }
         """
@@ -886,6 +888,8 @@ class E3DC:
             "startTimestamp": startTimestamp,
             "stateOfCharge": rscpFindTagIndex(response[2][0], "DB_BAT_CHARGE_LEVEL"),
             "solarProduction": rscpFindTagIndex(response[2][0], "DB_DC_POWER"),
+            "pm0Production": rscpFindTagIndex(response[2][0], "DB_PM_0_POWER"),
+            "pm1Production": rscpFindTagIndex(response[2][0], "DB_PM_1_POWER"),
             "timespanSeconds": timespanSeconds,
         }
 
@@ -916,6 +920,8 @@ class E3DC:
                     "startDate": <date from which db data is fetched of>,
                     "stateOfCharge": <battery charge level in %>,
                     "solarProduction": <power production>,
+                    "pm0Production": <power production>,
+                    "pm1Production": <power production>,
                     "timespan": <timespan of which db data is collected>,
                     "timespanSeconds": <timespan in seconds of which db data is collected>
                 }


### PR DESCRIPTION
If you have a second inverter attached to your E3DC you can read the current value vom "production/add" in the current release. But for the day statistics the db_day() method needs to extended to store also PM0_Power and for other purposes also the PM1_POWER field.