### PR TITLE
Fix error in voltages field

### DIFF
--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -1389,28 +1389,36 @@ class E3DC:
             voltages = []
 
             # Set temperatures, if available for the device
-            temps = rscpFindTag(req, RscpTag.BAT_DCB_ALL_CELL_TEMPERATURES)
-            if temps is not None and len(temps) == 3 and temps[1] != "Error":
-                temperatures_raw = rscpFindTagIndex(
+            temperatures_raw = rscpFindTag(req, RscpTag.BAT_DCB_ALL_CELL_TEMPERATURES)
+            if (
+                temperatures_raw is not None
+                and len(temperatures_raw) == 3
+                and temperatures_raw[1] != "Error"
+            ):
+                temperatures_data = rscpFindTagIndex(
                     rscpFindTag(req, RscpTag.BAT_DCB_ALL_CELL_TEMPERATURES),
                     RscpTag.BAT_DATA,
                 )
                 temperatures = []
                 sensorCount = rscpFindTagIndex(info, RscpTag.BAT_DCB_NR_SENSOR)
                 for sensor in range(0, sensorCount):
-                    temperatures.append(round(temperatures_raw[sensor][2], 2))
+                    temperatures.append(round(temperatures_data[sensor][2], 2))
 
             # Set voltages, if available for the device
-            voltages = rscpFindTag(req, RscpTag.BAT_DCB_ALL_CELL_VOLTAGES)
-            if voltages is not None and len(voltages) == 3 and voltages[1] != "Error":
-                voltages_raw = rscpFindTagIndex(
+            voltages_raw = rscpFindTag(req, RscpTag.BAT_DCB_ALL_CELL_VOLTAGES)
+            if (
+                voltages_raw is not None
+                and len(voltages_raw) == 3
+                and voltages_raw[1] != "Error"
+            ):
+                voltages_data = rscpFindTagIndex(
                     rscpFindTag(req, RscpTag.BAT_DCB_ALL_CELL_VOLTAGES),
                     RscpTag.BAT_DATA,
                 )
                 voltages = []
                 seriesCellCount = rscpFindTagIndex(info, RscpTag.BAT_DCB_NR_SERIES_CELL)
                 for cell in range(0, seriesCellCount):
-                    voltages.append(round(voltages_raw[cell][2], 2))
+                    voltages.append(round(voltages_data[cell][2], 2))
 
             dcbobj = {
                 "current": rscpFindTagIndex(info, RscpTag.BAT_DCB_CURRENT),

--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -1395,11 +1395,7 @@ class E3DC:
                 and len(temperatures_raw) == 3
                 and temperatures_raw[1] != "Error"
             ):
-                temperatures_data = rscpFindTagIndex(
-                    rscpFindTag(req, RscpTag.BAT_DCB_ALL_CELL_TEMPERATURES),
-                    RscpTag.BAT_DATA,
-                )
-                temperatures = []
+                temperatures_data = rscpFindTagIndex(temperatures_raw, RscpTag.BAT_DATA)
                 sensorCount = rscpFindTagIndex(info, RscpTag.BAT_DCB_NR_SENSOR)
                 for sensor in range(0, sensorCount):
                     temperatures.append(round(temperatures_data[sensor][2], 2))
@@ -1411,11 +1407,7 @@ class E3DC:
                 and len(voltages_raw) == 3
                 and voltages_raw[1] != "Error"
             ):
-                voltages_data = rscpFindTagIndex(
-                    rscpFindTag(req, RscpTag.BAT_DCB_ALL_CELL_VOLTAGES),
-                    RscpTag.BAT_DATA,
-                )
-                voltages = []
+                voltages_data = rscpFindTagIndex(voltages_raw, RscpTag.BAT_DATA)
                 seriesCellCount = rscpFindTagIndex(info, RscpTag.BAT_DCB_NR_SERIES_CELL)
                 for cell in range(0, seriesCellCount):
                     voltages.append(round(voltages_data[cell][2], 2))


### PR DESCRIPTION
Unfortunately in #86 there was a small problem that led to the "voltages" field containing an error message instead of being empty. This renames the problematic variables so it's clearer what the code does and the voltages object stays empty.

Old:
```
    "dcbs": {
      "0": {
        "current": null,
        "currentAvg30s": -0.4657486081123352,
        "cycleCount": null,
        "designCapacity": null,
        "designVoltage": null,
        "deviceName": null,
        "endOfDischarge": null,
        "error": null,
        "fullChargeCapacity": null,
        "fwVersion": null,
        "manufactureDate": null,
        "manufactureName": null,
        "maxChargeCurrent": null,
        "maxChargeTemperature": null,
        "maxChargeVoltage": null,
        "maxDischargeCurrent": null,
        "minChargeTemperature": null,
        "parallelCellCount": null,
        "sensorCount": 0,
        "seriesCellCount": 0,
        "pcbVersion": null,
        "protocolVersion": null,
        "remainingCapacity": null,
        "serialCode": null,
        "serialNo": null,
        "soc": null,
        "soh": null,
        "status": null,
        "temperatures": [],
        "voltage": null,
        "voltageAvg30s": 392.5743408203125,
        "voltages": [
          "BAT_DCB_ALL_CELL_VOLTAGES",
          "Error",
          "RSCP_ERR_OUT_OF_BOUNDS"
        ],
        "warning": null
      }
    },
```

New:
```
  "dcbs": {
    "0": {
      "current": null,
      "currentAvg30s": -0.5459553003311157,
      "cycleCount": null,
      "designCapacity": null,
      "designVoltage": null,
      "deviceName": null,
      "endOfDischarge": null,
      "error": null,
      "fullChargeCapacity": null,
      "fwVersion": null,
      "manufactureDate": null,
      "manufactureName": null,
      "maxChargeCurrent": null,
      "maxChargeTemperature": null,
      "maxChargeVoltage": null,
      "maxDischargeCurrent": null,
      "minChargeTemperature": null,
      "parallelCellCount": null,
      "sensorCount": 0,
      "seriesCellCount": 0,
      "pcbVersion": null,
      "protocolVersion": null,
      "remainingCapacity": null,
      "serialCode": null,
      "serialNo": null,
      "soc": null,
      "soh": null,
      "status": null,
      "temperatures": [],
      "voltage": null,
      "voltageAvg30s": 392.34014892578125,
      "voltages": [],
      "warning": null
    }
  },
```