### PR TITLE
remove websocket ingnore reportPrivateImportUsage

### DIFF
--- a/e3dc/_e3dc_rscp_web.py
+++ b/e3dc/_e3dc_rscp_web.py
@@ -13,7 +13,7 @@ import time
 from typing import Any, Callable, Tuple
 
 import tzlocal
-from websocket import ABNF, WebSocketApp  # pyright: ignore [reportPrivateImportUsage]
+from websocket import ABNF, WebSocketApp
 
 from ._rscpLib import (
     rscpDecode,


### PR DESCRIPTION
With `websocket-client` release `v1.8.0` `WebSocketApp` is correctly exported.
https://github.com/websocket-client/websocket-client/pull/958