### PR TITLE
Fix return value of set_weather_regulated_charge(enable=True)

### DIFF
--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -2397,39 +2397,20 @@ class E3DC:
             0 if success
             -1 if error
         """
-        if enable:
-            res = self.sendRequest(
-                (
-                    RscpTag.EMS_REQ_SET_POWER_SETTINGS,
-                    RscpType.Container,
-                    [
-                        (
-                            RscpTag.EMS_WEATHER_REGULATED_CHARGE_ENABLED,
-                            RscpType.UChar8,
-                            1,
-                        )
-                    ],
-                ),
-                keepAlive=keepAlive,
-            )
-        else:
-            res = self.sendRequest(
-                (
-                    RscpTag.EMS_REQ_SET_POWER_SETTINGS,
-                    RscpType.Container,
-                    [
-                        (
-                            RscpTag.EMS_WEATHER_REGULATED_CHARGE_ENABLED,
-                            RscpType.UChar8,
-                            0,
-                        )
-                    ],
-                ),
-                keepAlive=keepAlive,
-            )
+        res = self.sendRequest(
+            (
+                RscpTag.EMS_REQ_SET_POWER_SETTINGS,
+                RscpType.Container,
+                [
+                    (
+                        RscpTag.EMS_WEATHER_REGULATED_CHARGE_ENABLED,
+                        RscpType.UChar8,
+                        enable,
+                    )
+                ],
+            ),
+            keepAlive=keepAlive,
+        )
 
-        # validate return code for EMS_RES_WEATHER_REGULATED_CHARGE_ENABLED is 0
-        if res[2][0][2] == 0:
-            return 0
-        else:
-            return -1
+        # validate return code for EMS_RES_WEATHER_REGULATED_CHARGE_ENABLED being equal to requested new state
+        return res[2][0][2] == enable


### PR DESCRIPTION
In my tests `set_weather_regulated_charge()` with `enabled=True` always returned the code "1" instead of the expected 0.
For the same API disabling the weather regulated charge with `enabled=False` actually returns the expected `0`

Unfortunately I am not a expert of the RSCP protocol, but while debugging it looked to me that maybe the current state is returned instead of a `0`.
The state definitely changed properly to 'enabled' in the E3/DC portal, on the device itself and what `get_power_settings()` returned.