### PR TITLE
Add e3dc-cli to projects list

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ One limitation of the package concerns the implemented RSCP methods. This projec
 - [e3dc-to-mqtt](https://github.com/mdhom/e3dc-to-mqtt): publish E3/DC data via MQTT
 - [weewx-photovoltaics](https://github.com/roe-dl/weewx-photovoltaics): Extension to WeeWX for processing data of the photovoltaics system E3/DC
 - [hacs-e3dc](https://github.com/torbennehmer/hacs-e3dc): HACS Version of the E3DC Home Assistant integration
+- [e3dc-cli](https://github.com/waldbaer/e3dc-cli): a simple command line interface for interaction with an E3/DC system
 
 ## Contribution
 


### PR DESCRIPTION
For 2 years I used an initial local version of a small command line wrapper for the famous python-e3dc libary within my Node-RED home-automation.

Now it was time to make it open-source.

I would be happy if you could add it to the list of projects using the library.

Thanks for all your efforts!