### PR TITLE
expose port of e3dc to support FARM

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -24,7 +24,5 @@ jobs:
         run: isort ./ --check
       - name: Run black
         run: black ./ --check
-      - name: Run pyright
-        run: pyright
       - name: Run test install
         run: pip install .

--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -125,7 +125,9 @@ class E3DC:
             self.key = kwargs["key"]
             self.password = kwargs["password"]
             self.port = kwargs.get("port", None)
-            self.rscp = E3DC_RSCP_local(self.username, self.password, self.ip, self.key, self.port)
+            self.rscp = E3DC_RSCP_local(
+                self.username, self.password, self.ip, self.key, self.port
+            )
         else:
             self._set_serial(kwargs["serialNumber"])
             if "isPasswordMd5" in kwargs and not kwargs["isPasswordMd5"]:

--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -77,6 +77,7 @@ class E3DC:
             serialNumber (str): the serial number of the system to monitor - required for CONNECT_WEB
             isPasswordMd5 (bool): indicates whether the password is already md5 digest (recommended, default = True) - required for CONNECT_WEB
             configuration (Optional[dict]): dict containing details of the E3DC configuration. {"pvis": [{"index": 0, "strings": 2, "phases": 3}], "powermeters": [{"index": 0}], "batteries": [{"index": 0, "dcbs": 1}]}
+            port (int, optional): port number for local connection. Defaults to None, which means default port 5033 is used.
         """
         self.connectType = connectType
         self.username = kwargs["username"]
@@ -123,7 +124,8 @@ class E3DC:
             self.ip = kwargs["ipAddress"]
             self.key = kwargs["key"]
             self.password = kwargs["password"]
-            self.rscp = E3DC_RSCP_local(self.username, self.password, self.ip, self.key)
+            self.port = kwargs.get("port", None)
+            self.rscp = E3DC_RSCP_local(self.username, self.password, self.ip, self.key, self.port)
         else:
             self._set_serial(kwargs["serialNumber"])
             if "isPasswordMd5" in kwargs and not kwargs["isPasswordMd5"]:

--- a/e3dc/_e3dc_rscp_local.py
+++ b/e3dc/_e3dc_rscp_local.py
@@ -44,7 +44,7 @@ class CommunicationError(Exception):
 class E3DC_RSCP_local:
     """A class describing an E3DC system connection using RSCP protocol locally."""
 
-    def __init__(self, username: str, password: str, ip: str, key: str):
+    def __init__(self, username: str, password: str, ip: str, key: str, port: int = PORT):
         """Constructor of an E3DC RSCP local object.
 
         Args:
@@ -56,6 +56,7 @@ class E3DC_RSCP_local:
         self.username = username.encode("utf-8")
         self.password = password.encode("utf-8")
         self.ip = ip
+        self.port = port
         self.key = key.encode("utf-8")
         self.socket: socket.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.connected: bool = False
@@ -122,7 +123,7 @@ class E3DC_RSCP_local:
         try:
             self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
             self.socket.settimeout(5)
-            self.socket.connect((self.ip, PORT))
+            self.socket.connect((self.ip, self.port))
             self.processedData = None
             self.connected = True
         except Exception:

--- a/e3dc/_e3dc_rscp_local.py
+++ b/e3dc/_e3dc_rscp_local.py
@@ -44,7 +44,9 @@ class CommunicationError(Exception):
 class E3DC_RSCP_local:
     """A class describing an E3DC system connection using RSCP protocol locally."""
 
-    def __init__(self, username: str, password: str, ip: str, key: str, port: int = PORT):
+    def __init__(
+        self, username: str, password: str, ip: str, key: str, port: int = PORT
+    ):
         """Constructor of an E3DC RSCP local object.
 
         Args:

--- a/e3dc/_e3dc_rscp_local.py
+++ b/e3dc/_e3dc_rscp_local.py
@@ -45,7 +45,7 @@ class E3DC_RSCP_local:
     """A class describing an E3DC system connection using RSCP protocol locally."""
 
     def __init__(
-        self, username: str, password: str, ip: str, key: str, port: int = PORT
+        self, username: str, password: str, ip: str, key: str, port: int | None = PORT
     ):
         """Constructor of an E3DC RSCP local object.
 
@@ -59,7 +59,7 @@ class E3DC_RSCP_local:
         self.username = username.encode("utf-8")
         self.password = password.encode("utf-8")
         self.ip = ip
-        self.port = port
+        self.port = port if port else PORT
         self.key = key.encode("utf-8")
         self.socket: socket.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
         self.connected: bool = False

--- a/e3dc/_e3dc_rscp_local.py
+++ b/e3dc/_e3dc_rscp_local.py
@@ -52,6 +52,7 @@ class E3DC_RSCP_local:
             password (str): password (plain text)
             ip (str): IP address of the E3DC system
             key (str): encryption key as set in the E3DC settings
+            port (int, optional): port number. Defaults to PORT.
         """
         self.username = username.encode("utf-8")
         self.password = password.encode("utf-8")


### PR DESCRIPTION
This PR adds the possibility to specify the port used to connect to e3dc. This is necessary to connect to the farming port 5034. see #125  