### PR TITLE
Battery_temp_sensor_fix

### DIFF
--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -1568,7 +1568,11 @@ class E3DC:
             ):
                 temperatures_data = rscpFindTagIndex(temperatures_raw, RscpTag.BAT_DATA)
                 sensorCount = rscpFindTagIndex(info, RscpTag.BAT_DCB_NR_SENSOR)
-                for sensor in range(0, sensorCount):
+                
+                # As sensorCount can return bigger values than we have actual temperatures_data,
+                # we use the smaller count for robustness.
+                sensors = min(sensorCount, len(temperatures_data))
+                for sensor in range(0, sensors):
                     temperatures.append(temperatures_data[sensor][2])
 
             # Set voltages, if available for the device


### PR DESCRIPTION
This Fix removes the issue as described in https://github.com/fsantini/python-e3dc/issues/130.

For some reasons BAT_DCB_NR_SENSOR returns high values (35 in my case), while the actual S10X Compact has only 5 temperature sensors.

For robustness measures, this fix checks the amount of acual received temperature values and uses the smaller amount, to not overshoot the array of received sensor values.