### PR TITLE
fixed battery temp sensor fail

### DIFF
--- a/e3dc/_e3dc.py
+++ b/e3dc/_e3dc.py
@@ -1568,7 +1568,7 @@ class E3DC:
             ):
                 temperatures_data = rscpFindTagIndex(temperatures_raw, RscpTag.BAT_DATA)
                 sensorCount = rscpFindTagIndex(info, RscpTag.BAT_DCB_NR_SENSOR)
-                
+
                 # As sensorCount can return bigger values than we have actual temperatures_data,
                 # we use the smaller count for robustness.
                 sensors = min(sensorCount, len(temperatures_data))


### PR DESCRIPTION
As described in https://github.com/fsantini/python-e3dc/issues/130, get_battery_data() can fail if BAT_DCB_NR_SENSOR returns a bigger value than acutal temperature sensor values delivered.
This simple fix assures that the index for actual temperature sensor values cannot overshoot.