### PR TITLE
Improve RSCP frame reception handling to ensure complete frames are processed

### DIFF
--- a/e3dc/_e3dc_rscp_local.py
+++ b/e3dc/_e3dc_rscp_local.py
@@ -5,9 +5,10 @@
 # Licensed under a MIT license. See LICENSE for details
 
 import socket
+import struct
 
 from ._RSCPEncryptDecrypt import RSCPEncryptDecrypt
-from ._rscpLib import RscpMessage, rscpDecode, rscpEncode, rscpFrame
+from ._rscpLib import RscpMessage, rscpDecode, rscpEncode, rscpFrame, rscpFrameDecode
 from ._rscpTags import RscpError, RscpTag, RscpType
 
 DEFAULT_PORT = 5033
@@ -69,11 +70,22 @@ class E3DC_RSCP_local:
         self.socket.send(encData)
 
     def _receive(self):
-        data = self.socket.recv(BUFFER_SIZE)
-        if len(data) == 0:
-            raise RSCPKeyError
-        decData = rscpDecode(self.encdec.decrypt(data))[0]
-        return decData
+        # A single socket.recv() call is not guaranteed to return a complete
+        # RSCP frame (large responses can be split across multiple TCP reads),
+        # so keep receiving and decrypting until a full frame is available.
+        decData = b""
+        while True:
+            data = self.socket.recv(BUFFER_SIZE)
+            if len(data) == 0:
+                raise RSCPKeyError
+            decData += self.encdec.decrypt(data)
+            try:
+                rscpFrameDecode(decData)
+            except struct.error:
+                # not enough data yet for a full frame: keep receiving
+                continue
+            break
+        return rscpDecode(decData)[0]
 
     def sendCommand(self, plainMsg: RscpMessage) -> None:
         """Sending RSCP command.

--- a/e3dc/_rscpLib.py
+++ b/e3dc/_rscpLib.py
@@ -148,7 +148,7 @@ def rscpEncode(
     rscptypeHex = getHexRscpType(rscptype)
     rscptype = getRscpType(rscptype)
 
-    loggable_data = '<redacted>' if tag in (RscpTag.SERVER_PASSWD, RscpTag.SERVER_USER ) else data
+    loggable_data = '<redacted>' if tag in (RscpTag.SERVER_PASSWD, RscpTag.SERVER_USER) else data
     logger.debug("> %s %s %s", tag, rscptype, loggable_data)
 
     if isinstance(data, str):


### PR DESCRIPTION
Tag EH_REQ_GET_SAVED_ERRORS returns a large amount of data (approx 4k on my end), which gets split by TCP in multiple chunks.

Sample code:

```
print("query EH_REQ_GET_SAVED_ERRORS")
result = e3dc.sendRequest((RscpTag.EH_REQ_GET_SAVED_ERRORS, RscpType.NoneType, None))
print(json.dumps(result, indent=2, default=str))
```

This yields:

```
Traceback (most recent call last):
  File "/home/torben/src/python-e3dc/e3dc/_e3dc_rscp_local.py", line 97, in sendRequest
    receive = self._receive()
  File "/home/torben/src/python-e3dc/e3dc/_e3dc_rscp_local.py", line 75, in _receive
    decData = rscpDecode(self.encdec.decrypt(data))[0]
              ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/torben/src/python-e3dc/e3dc/_rscpLib.py", line 262, in rscpDecode
    return rscpDecode(rscpFrameDecode(data)[0])
                      ~~~~~~~~~~~~~~~^^^^^^
  File "/home/torben/src/python-e3dc/e3dc/_rscpLib.py", line 223, in rscpFrameDecode
    data, crc = struct.unpack(
                ~~~~~~~~~~~~~^
        "<" + str(length) + "s" + crcFmt,
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        frameData[struct.calcsize(headerFmt) : totalLen],
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
struct.error: unpack requires a buffer of 4216 bytes
```

Altering the receive call to a loop fixes the problem, it assembles the frame appropriately. Tested various other calls to ensure correct functionality.

Prerequisite for hacs-e3dc PR https://github.com/torbennehmer/hacs-e3dc/pull/373